### PR TITLE
Fix compilation with newer Qt 5 versions

### DIFF
--- a/UI/qwt/src/qwt_transform.h
+++ b/UI/qwt/src/qwt_transform.h
@@ -12,6 +12,14 @@
 
 #include "qwt_global.h"
 
+#ifndef QT_STATIC_CONST
+#define QT_STATIC_CONST static const
+#endif
+
+#ifndef QT_STATIC_CONST_IMPL
+#define QT_STATIC_CONST_IMPL const
+#endif
+
 /*!
    \brief A transformation between coordinate systems
 


### PR DESCRIPTION
According to various sources both constants were removed in Qt 5.4.
Thanks to "Ilya87" for reporting a solution here:
https://aur.archlinux.org/packages/libqxt-qt5-git/
